### PR TITLE
77 styling schedule with proper timeslot

### DIFF
--- a/client/src/components/Login/LoginBox.tsx
+++ b/client/src/components/Login/LoginBox.tsx
@@ -20,7 +20,7 @@ function LoginBox({ }: Props) {
         Don't have an account? { }
         <a
           rel="noopener noreferrer"
-          href="#"
+          href="/signup"
           className="underline dark:text-gray-100"
         >
           Sign up

--- a/client/src/components/Login/LoginForm.tsx
+++ b/client/src/components/Login/LoginForm.tsx
@@ -26,8 +26,8 @@ function LoginForm({}: Props) {
             type="password"
             name="password"
             id="password"
-            placeholder="Password"
-            className="w-full px-4 py-3 text-sm rounded-md dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 focus:dark:border-violet-400"
+            placeholder="••••••••"
+            className="w-full text-sm px-4 py-3 bg-gray-50 rounded-md border-gray-100  dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 focus:dark:border-violet-400"
           />
           <div className="flex justify-end text-xs dark:text-gray-400">
             <a rel="noopener noreferrer" href="#">

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -37,18 +37,19 @@ const Navbar = () => {
               jdoe@flowbite.com
             </span>
           </Dropdown.Header>
-          <Link to={'/'}>
-            <Dropdown.Item>Home</Dropdown.Item>
+          <Link to={'/auth/schedule'}>
+            <Dropdown.Item>My Schedule</Dropdown.Item>
           </Link>
-          <Dropdown.Item>My Schedule</Dropdown.Item>
-          <Link to={'/findUsers'}>
+          <Link to={'/auth/findUsers'}>
             <Dropdown.Item>Find Users</Dropdown.Item>
           </Link>
-          <Link to={'/account'}>
+          <Link to={'/auth/account'}>
             <Dropdown.Item>Account Settings</Dropdown.Item>
           </Link>
           <Dropdown.Divider />
-          <Dropdown.Item>Sign out</Dropdown.Item>
+          <Link to={'/'}>
+            <Dropdown.Item>Sign out</Dropdown.Item>
+          </Link>
         </Dropdown>
       </div>
     </div>

--- a/client/src/components/Schedule/ScheduleBox.tsx
+++ b/client/src/components/Schedule/ScheduleBox.tsx
@@ -12,7 +12,7 @@ function ScheduleBox({}: Props) {
           <div>Friday</div>
         </div>
 
-        <div className="h-[936px] rounded bg-slate-600">
+        <div className="h-[1008px] rounded mb-6 bg-white dark:bg-black dark:text-white">
           <div className="relative h-[936px]">
             <span className="absolute top-[0px]">7</span>
             <span className="absolute top-[72px]">8</span>

--- a/client/src/components/Schedule/ScheduleBox.tsx
+++ b/client/src/components/Schedule/ScheduleBox.tsx
@@ -30,11 +30,29 @@ function ScheduleBox({}: Props) {
               <span className="absolute top-[936px]">8</span>
             </div>
           </div>
-          <div className=" left-[100px] top-[0px] flex h-[1008px] w-1/5 flex-col  bg-purple-500"></div>
-          <div className=" left-[100px] top-[0px] flex h-[1008px] w-1/5 flex-col  bg-red-500"></div>
-          <div className=" left-[100px] top-[0px] flex h-[1008px] w-1/5 flex-col  bg-orange-500"></div>
-          <div className=" left-[100px] top-[0px] flex h-[1008px] w-1/5 flex-col  bg-blue-500"></div>
-          <div className=" left-[100px] top-[0px] flex h-[1008px] w-1/5 flex-col  bg-green-500"></div>
+          <div className="relative h-[1008px] w-1/5 bg-purple-500">
+            <div className="flex justify-center">
+              <div className="absolute top-[0px] h-[72px] w-3/4 rounded bg-white"> {/* 7 AM starting so start at 0 px*/}
+                7 AM - 8 AM {/* 1 hours total = 72 px*/}
+              </div>
+            </div>
+          </div>
+          <div className="relative h-[1008px] w-1/5 bg-red-500"></div>
+          <div className="relative h-[1008px] w-1/5 bg-green-500">
+            <div className="flex justify-center">
+              <div className="absolute top-[252px] h-[144px] w-3/4 rounded bg-white"> {/* 10:30 AM starting so start at 252 px*/}
+                10:30 AM - 12:30 PM {/* 2 hours total = 144 px*/}
+              </div>
+            </div>
+          </div>
+          <div className="relative h-[1008px] w-1/5 bg-blue-500">
+            <div className="flex justify-center">
+              <div className="absolute top-[0px] h-[72px] w-3/4 rounded bg-white">
+                7 AM - 8 AM {/* 1 hours total = 72 px*/}
+              </div>
+            </div>
+          </div>
+          <div className="relative h-[1008px] w-1/5 bg-teal-500"></div>
         </div>
       </div>
     </>

--- a/client/src/components/Schedule/ScheduleBox.tsx
+++ b/client/src/components/Schedule/ScheduleBox.tsx
@@ -1,13 +1,39 @@
-import React from 'react'
-
-type Props = {}
+type Props = {};
 
 function ScheduleBox({}: Props) {
   return (
-    <div className="w-3/4 flex items-center justify-center bg-slate-700 text-lg text-white rounded-lg">
-      Schedule
-    </div>
-  )
+    <>
+      <div className="flex w-full flex-col">
+        <div className="flex justify-evenly dark:text-white">
+          <div>Monday</div>
+          <div>Tuesday</div>
+          <div>Wednesday</div>
+          <div>Thursday</div>
+          <div>Friday</div>
+        </div>
+
+        <div className="h-[936px] rounded bg-slate-600">
+          <div className="relative h-[936px]">
+            <span className="absolute top-[0px]">7</span>
+            <span className="absolute top-[72px]">8</span>
+            <span className="absolute top-[144px]">9</span>
+            <span className="absolute top-[216px]">10</span>
+            <span className="absolute top-[288px]">11</span>
+            <span className="absolute top-[360px]">12</span>
+            <span className="absolute top-[432px]">1</span>
+            <span className="absolute top-[504px]">2</span>
+            <span className="absolute top-[576px]">3</span>
+            <span className="absolute top-[648px]">4</span>
+            <span className="absolute top-[720px]">5</span>
+            <span className="absolute top-[792px]">6</span>
+            <span className="absolute top-[864px]">7</span>
+            <span className="absolute top-[936px]">8</span>
+          </div>
+          <div className="relative"></div>
+        </div>
+      </div>
+    </>
+  );
 }
 
-export default ScheduleBox
+export default ScheduleBox;

--- a/client/src/components/Schedule/ScheduleBox.tsx
+++ b/client/src/components/Schedule/ScheduleBox.tsx
@@ -1,3 +1,5 @@
+import TimeSlot from './TimeSlot';
+
 type Props = {};
 
 function ScheduleBox({}: Props) {
@@ -32,24 +34,22 @@ function ScheduleBox({}: Props) {
           </div>
           <div className="relative h-[1008px] w-1/5 bg-purple-500">
             <div className="flex justify-center">
-              <div className="absolute top-[0px] h-[72px] w-3/4 rounded bg-white"> {/* 7 AM starting so start at 0 px*/}
-                7 AM - 8 AM {/* 1 hours total = 72 px*/}
-              </div>
+              <TimeSlot top="0px" height="72px" time="7 AM - 8 AM" />
             </div>
           </div>
-          <div className="relative h-[1008px] w-1/5 bg-red-500"></div>
+          <div className="relative h-[1008px] w-1/5 bg-red-500">
+            <div className="flex justify-center">
+              <TimeSlot top="72px" height="72px" time="8 AM - 9 AM" />
+            </div>
+          </div>
           <div className="relative h-[1008px] w-1/5 bg-green-500">
             <div className="flex justify-center">
-              <div className="absolute top-[252px] h-[144px] w-3/4 rounded bg-white"> {/* 10:30 AM starting so start at 252 px*/}
-                10:30 AM - 12:30 PM {/* 2 hours total = 144 px*/}
-              </div>
+              <TimeSlot top="252px" height="144px" time="10:30 AM - 12:30 PM" />
             </div>
           </div>
           <div className="relative h-[1008px] w-1/5 bg-blue-500">
             <div className="flex justify-center">
-              <div className="absolute top-[0px] h-[72px] w-3/4 rounded bg-white">
-                7 AM - 8 AM {/* 1 hours total = 72 px*/}
-              </div>
+              <TimeSlot top="0px" height="72px" time="7 AM - 8 AM" />
             </div>
           </div>
           <div className="relative h-[1008px] w-1/5 bg-teal-500"></div>

--- a/client/src/components/Schedule/ScheduleBox.tsx
+++ b/client/src/components/Schedule/ScheduleBox.tsx
@@ -11,25 +11,30 @@ function ScheduleBox({}: Props) {
           <div>Thursday</div>
           <div>Friday</div>
         </div>
-
-        <div className="h-[1008px] rounded mb-6 bg-white dark:bg-black dark:text-white">
-          <div className="relative h-[936px]">
-            <span className="absolute top-[0px]">7</span>
-            <span className="absolute top-[72px]">8</span>
-            <span className="absolute top-[144px]">9</span>
-            <span className="absolute top-[216px]">10</span>
-            <span className="absolute top-[288px]">11</span>
-            <span className="absolute top-[360px]">12</span>
-            <span className="absolute top-[432px]">1</span>
-            <span className="absolute top-[504px]">2</span>
-            <span className="absolute top-[576px]">3</span>
-            <span className="absolute top-[648px]">4</span>
-            <span className="absolute top-[720px]">5</span>
-            <span className="absolute top-[792px]">6</span>
-            <span className="absolute top-[864px]">7</span>
-            <span className="absolute top-[936px]">8</span>
+        <div className="mb-6 flex h-[1008px] rounded bg-white dark:bg-black dark:text-white">
+          <div className="h-[1008px] w-[20px]">
+            <div className="relative">
+              <span className="absolute top-[0px]">7</span>
+              <span className="absolute top-[72px]">8</span>
+              <span className="absolute top-[144px]">9</span>
+              <span className="absolute top-[216px]">10</span>
+              <span className="absolute top-[288px]">11</span>
+              <span className="absolute top-[360px]">12</span>
+              <span className="absolute top-[432px]">1</span>
+              <span className="absolute top-[504px]">2</span>
+              <span className="absolute top-[576px]">3</span>
+              <span className="absolute top-[648px]">4</span>
+              <span className="absolute top-[720px]">5</span>
+              <span className="absolute top-[792px]">6</span>
+              <span className="absolute top-[864px]">7</span>
+              <span className="absolute top-[936px]">8</span>
+            </div>
           </div>
-          <div className="relative"></div>
+          <div className=" left-[100px] top-[0px] flex h-[1008px] w-1/5 flex-col  bg-purple-500"></div>
+          <div className=" left-[100px] top-[0px] flex h-[1008px] w-1/5 flex-col  bg-red-500"></div>
+          <div className=" left-[100px] top-[0px] flex h-[1008px] w-1/5 flex-col  bg-orange-500"></div>
+          <div className=" left-[100px] top-[0px] flex h-[1008px] w-1/5 flex-col  bg-blue-500"></div>
+          <div className=" left-[100px] top-[0px] flex h-[1008px] w-1/5 flex-col  bg-green-500"></div>
         </div>
       </div>
     </>

--- a/client/src/components/Schedule/TimeBlockInput.tsx
+++ b/client/src/components/Schedule/TimeBlockInput.tsx
@@ -1,3 +1,5 @@
+import ColorsPalette from '../Utils/ColorsPalette';
+
 type Props = {};
 
 function TimeBlockInput({}: Props) {
@@ -18,7 +20,8 @@ function TimeBlockInput({}: Props) {
     'rose',
   ];
   return (
-    <div className="flex h-1/4 w-1/2 mt-6 flex-col rounded-lg bg-slate-50 p-5 dark:bg-black sm:h-1/2">
+    <div className="mt-6 flex h-1/4 w-1/2 flex-col rounded-lg bg-slate-50 p-5 dark:bg-black sm:h-1/2">
+      <ColorsPalette />
       <div>
         <label
           htmlFor="title"

--- a/client/src/components/Schedule/TimeBlockInput.tsx
+++ b/client/src/components/Schedule/TimeBlockInput.tsx
@@ -18,7 +18,7 @@ function TimeBlockInput({}: Props) {
     'rose',
   ];
   return (
-    <div className="flex h-5/6 w-1/2 flex-col rounded-lg bg-slate-50 p-5 dark:bg-black sm:h-1/2">
+    <div className="flex h-1/4 w-1/2 mt-6 flex-col rounded-lg bg-slate-50 p-5 dark:bg-black sm:h-1/2">
       <div>
         <label
           htmlFor="title"

--- a/client/src/components/Schedule/TimeSlot.tsx
+++ b/client/src/components/Schedule/TimeSlot.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+type Props = {
+  top: string;
+  height: string;
+  time : string;
+};
+
+function TimeSlot(props: Props) {
+  return (
+    <div className={`absolute top-[${props.top}] h-[${props.height}] w-3/4 rounded bg-white`}>
+     {props.time}
+    </div>
+  );
+}
+
+export default TimeSlot;

--- a/client/src/components/Schedule/TimeSlotInput.tsx
+++ b/client/src/components/Schedule/TimeSlotInput.tsx
@@ -2,7 +2,7 @@ import ColorsPalette from '../Utils/ColorsPalette';
 
 type Props = {};
 
-function TimeBlockInput({}: Props) {
+function TimeSlotInput({}: Props) {
   const colors: string[] = [
     'slate',
     'red',
@@ -211,4 +211,4 @@ function TimeBlockInput({}: Props) {
   );
 }
 
-export default TimeBlockInput;
+export default TimeSlotInput;

--- a/client/src/components/Signup/SignUpBox.tsx
+++ b/client/src/components/Signup/SignUpBox.tsx
@@ -4,19 +4,27 @@ type Props = {};
 
 function SignUpBox({}: Props) {
   return (
-    <div className='flex w-5/6 h-full md:w-2/3 lg:w-1/3 flex-col bg-gray-100 dark:bg-slate-800  rounded-lg p-10 dark:text-gray-100'>
-      <div className='flex justify-center text-4xl md:text-5xl mb-5 dark:text-white'>
+    <div className="flex h-full w-5/6 flex-col rounded-lg bg-gray-100 p-10 dark:bg-slate-800  dark:text-gray-100 md:w-2/3 lg:w-1/3">
+      <div className="mb-5 flex justify-center text-4xl dark:text-white md:text-5xl">
         Sign up
       </div>
-      <SignUpForm/>
-      <div className="flex items-center pt-4 space-x-1">
-        <div className="flex-1 h-px sm:w-16 bg-gray-900 dark:bg-gray-700"></div>
-        <p className="px-3 text-sm dark:text-gray-400">
-          Login with Google
-        </p>
-        <div className="flex-1 h-px sm:w-16 bg-gray-900 dark:bg-gray-700"></div>
+      <SignUpForm />
+      <div className="flex items-center space-x-1 pt-4">
+        <div className="h-px flex-1 bg-gray-900 dark:bg-gray-700 sm:w-16"></div>
+        <p className="px-3 text-sm dark:text-gray-400">Login with Google</p>
+        <div className="h-px flex-1 bg-gray-900 dark:bg-gray-700 sm:w-16"></div>
       </div>
-      <GoogleAuth/>
+      <GoogleAuth />
+      <p className="text-center text-xs dark:text-gray-400 sm:px-6">
+        Have an account? {}
+        <a
+          rel="noopener noreferrer"
+          href="/login"
+          className="underline dark:text-gray-100"
+        >
+          Login
+        </a>
+      </p>
     </div>
   );
 }

--- a/client/src/components/Utils/ColorsPalette.tsx
+++ b/client/src/components/Utils/ColorsPalette.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+type Props = {};
+
+function ColorsPalette({}: Props) {
+  return (
+    <div className="hidden">
+      <div className="bg-slate-400"></div>
+      <div className="bg-red-400"></div>
+      <div className="bg-orange-400"></div>
+      <div className="bg-amber-400"></div>
+      <div className="bg-yellow-400"></div>
+      <div className="bg-lime-400"></div>
+      <div className="bg-green-400"></div>
+      <div className="bg-emerald-400"></div>
+      <div className="bg-teal-400"></div>
+      <div className="bg-blue-400"></div>
+      <div className="bg-violet-400"></div>
+      <div className="bg-purple-400"></div>
+      <div className="bg-fuchsia-400"></div>
+      <div className="bg-rose-400"></div>
+    </div>
+  );
+}
+
+export default ColorsPalette;

--- a/client/src/pages/Homepage.tsx
+++ b/client/src/pages/Homepage.tsx
@@ -4,10 +4,12 @@ import scheduleImg from '../assets/schedule.png';
 import { AiFillGithub } from 'react-icons/ai';
 type Props = {};
 
-function Homepage({ }: Props) {
+function Homepage({}: Props) {
   const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
   const [width, setWidth] = useState<number>(window.innerWidth);
-  const [theme, setTheme] = useState<string>(mediaQuery.matches ? 'white' : 'black');
+  const [theme, setTheme] = useState<string>(
+    mediaQuery.matches ? 'white' : 'black'
+  );
   useEffect(() => {
     const handleResize = () => {
       setWidth(window.innerWidth);
@@ -29,7 +31,7 @@ function Homepage({ }: Props) {
           <div className="flex justify-center text-5xl dark:text-white">
             ScheduleFinder
           </div>
-          <p className="flex justify-center p-3 dark:text-white font-medium">
+          <p className="flex justify-center p-3 font-medium dark:text-white">
             Easily create schedules to see your friends. <br />
             Discover new people within your free time periods.
           </p>
@@ -37,11 +39,14 @@ function Homepage({ }: Props) {
             <button
               type="submit"
               form="changes"
-              className="w-1/2 rounded-full bg-blue-600 px-8 py-3 font-semibold text-white"
+              className="w-1/2 items-center rounded-full bg-blue-600 px-8 py-3 font-semibold text-white"
             >
               Get Started
             </button>
-            <a className='cursor-pointer w-3' href={'https://github.com/KyoshiNoda/ScheduleFinder'}>
+            <a
+              className="w-3 cursor-pointer"
+              href={'https://github.com/KyoshiNoda/ScheduleFinder'}
+            >
               <AiFillGithub size={'96'} color={`${theme}`} />
             </a>
           </div>
@@ -49,29 +54,40 @@ function Homepage({ }: Props) {
         </div>
       ) : (
         <div className="flex flex-col">
-          <div className="p-7 flex items-center">
-            <div className="flex-1 mr-1 items-center w-1/2">
+          <div className="flex items-center p-7">
+            <div className="mr-1 w-1/2 flex-1 items-center">
               <img src={scheduleImg} className="inline-block w-full max-w-md" />
             </div>
-            <div className="flex-1 flex flex-col justify-center items-center text-5xl lg:text-7xl dark:text-white">
+            <div className="flex flex-1 flex-col items-center justify-center text-5xl dark:text-white lg:text-7xl ml-60">
               <div className="my-auto">ScheduleFinder</div>
             </div>
           </div>
-          <div className="flex gap-28 p-3">
-            <div className='w-1/2 inline-block'>
-              <p className="dark:text-white text-lg  font-medium">
+          <div className="flex p-3">
+            <div className="inline-block w-1/2">
+              <p className="text-lg font-medium  dark:text-white">
                 Easily create schedules to see your friends. <br />
                 Discover new people within your free time periods.
               </p>
             </div>
-            <a
-              className="flex justify-center w-2/5 float-right rounded-full bg-blue-600 px-8 py-3 text-xl font-semibold text-white"
-              href={'/signup'}
-            >
-              Get Started
-            </a>
+            <div className="ml-56 flex w-1/2 flex-col gap-2">
+              <a
+                className="flex h-1/2 w-full items-center justify-center rounded-full bg-blue-600 dark:bg-blue-800 px-8 py-3 text-xl font-semibold text-white"
+                href={'/signup'}
+              >
+                Get Started
+              </a>
+              <a
+                className="flex h-1/2  w-full items-center justify-center rounded-full bg-blue-600  dark:bg-blue-800 px-8 py-3 text-xl font-semibold text-white"
+                href={'/login'}
+              >
+                Login
+              </a>
+            </div>
           </div>
-          <a className='cursor-pointer w-3' href={'https://github.com/KyoshiNoda/ScheduleFinder'}>
+          <a
+            className="w-3 cursor-pointer"
+            href={'https://github.com/KyoshiNoda/ScheduleFinder'}
+          >
             <AiFillGithub size={'96'} color={`${theme}`} />
           </a>
         </div>

--- a/client/src/pages/Homepage.tsx
+++ b/client/src/pages/Homepage.tsx
@@ -35,22 +35,34 @@ function Homepage({}: Props) {
             Easily create schedules to see your friends. <br />
             Discover new people within your free time periods.
           </p>
-          <div className="flex justify-center gap-1">
-            <button
-              type="submit"
-              form="changes"
-              className="w-1/2 items-center rounded-full bg-blue-600 px-8 py-3 font-semibold text-white"
-            >
-              Get Started
-            </button>
-            <a
-              className="w-3 cursor-pointer"
-              href={'https://github.com/KyoshiNoda/ScheduleFinder'}
-            >
-              <AiFillGithub size={'96'} color={`${theme}`} />
-            </a>
-          </div>
           <img src={scheduleImg} className="max-w-screen-sm text-center" />
+          <div className="flex justify-center gap-1">
+            <div className="self-center">
+              <a
+                className="flex h-1/2  w-full items-center justify-center rounded-full bg-blue-600  px-8 py-3 text-xl font-semibold text-white dark:bg-blue-800"
+                href={'/signup'}
+              >
+                Get Started
+              </a>
+            </div>
+
+            <div>
+              <a
+                className="w-3 cursor-pointer"
+                href={'https://github.com/KyoshiNoda/ScheduleFinder'}
+              >
+                <AiFillGithub size={'96'} color={`${theme}`} />
+              </a>
+            </div>
+            <div className="self-center">
+              <a
+                className="flex h-1/2  w-full items-center justify-center rounded-full bg-blue-600  px-8 py-3 text-xl font-semibold text-white dark:bg-blue-800"
+                href={'/login'}
+              >
+                Login
+              </a>
+            </div>
+          </div>
         </div>
       ) : (
         <div className="flex flex-col">
@@ -58,7 +70,7 @@ function Homepage({}: Props) {
             <div className="mr-1 w-1/2 flex-1 items-center">
               <img src={scheduleImg} className="inline-block w-full max-w-md" />
             </div>
-            <div className="flex flex-1 flex-col items-center justify-center text-5xl dark:text-white lg:text-7xl ml-60">
+            <div className="ml-60 flex flex-1 flex-col items-center justify-center text-5xl dark:text-white lg:text-7xl">
               <div className="my-auto">ScheduleFinder</div>
             </div>
           </div>
@@ -71,13 +83,13 @@ function Homepage({}: Props) {
             </div>
             <div className="ml-56 flex w-1/2 flex-col gap-2">
               <a
-                className="flex h-1/2 w-full items-center justify-center rounded-full bg-blue-600 dark:bg-blue-800 px-8 py-3 text-xl font-semibold text-white"
+                className="flex h-1/2 w-full items-center justify-center rounded-full bg-blue-600 px-8 py-3 text-xl font-semibold text-white dark:bg-blue-800"
                 href={'/signup'}
               >
                 Get Started
               </a>
               <a
-                className="flex h-1/2  w-full items-center justify-center rounded-full bg-blue-600  dark:bg-blue-800 px-8 py-3 text-xl font-semibold text-white"
+                className="flex h-1/2  w-full items-center justify-center rounded-full bg-blue-600  px-8 py-3 text-xl font-semibold text-white dark:bg-blue-800"
                 href={'/login'}
               >
                 Login

--- a/client/src/pages/Schedule.tsx
+++ b/client/src/pages/Schedule.tsx
@@ -66,7 +66,6 @@ function Schedule({}: Props) {
       </div>
       <div className="flex gap-10">
         <ScheduleBox />
-
         <TimeBlockInput />
       </div>
     </div>

--- a/client/src/pages/Schedule.tsx
+++ b/client/src/pages/Schedule.tsx
@@ -60,12 +60,13 @@ function Schedule({}: Props) {
   console.log(totalTime);
 
   return (
-    <div className="flex min-h-full flex-col gap-10 bg-slate-400 p-5 dark:bg-slate-900">
+    <div className="flex min-h-full flex-col gap-10 bg-slate-400 px-5 dark:bg-slate-900">
       <div className="flex justify-end">
         <Toggle />
       </div>
-      <div className="flex h-screen gap-12">
+      <div className="flex gap-10">
         <ScheduleBox />
+
         <TimeBlockInput />
       </div>
     </div>

--- a/client/src/pages/Schedule.tsx
+++ b/client/src/pages/Schedule.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import TimeBlockInput from '../components/Schedule/TimeBlockInput';
+import TimeSlotInput from '../components/Schedule/TimeSlotInput';
 import ScheduleBox from '../components/Schedule/ScheduleBox';
 import Toggle from '../components/Toggle';
 import Axios from 'axios';
@@ -66,7 +66,7 @@ function Schedule({}: Props) {
       </div>
       <div className="flex gap-10">
         <ScheduleBox />
-        <TimeBlockInput />
+        <TimeSlotInput />
       </div>
     </div>
   );


### PR DESCRIPTION
### 1) Added Schedule Styles with accurate timeSlots positions
**_NOTES:_** Background colors simply represent the column of each day (will remove after development)
<img width="1661" alt="Screenshot 2023-04-03 at 3 13 01 PM" src="https://user-images.githubusercontent.com/62672803/229604686-076f512f-3d8e-495d-8517-734f9942d195.png">
### 2)Fixed Schedule Container Height and tailwindCSS color palette bug 
<img width="560" alt="Screenshot 2023-04-03 at 3 09 59 PM" src="https://user-images.githubusercontent.com/62672803/229604012-c6499524-e404-440f-987e-dd0aef49a813.png">

### 3) Fixed Navigation and improved UX for users
<img width="210" alt="Screenshot 2023-04-03 at 3 11 56 PM" src="https://user-images.githubusercontent.com/62672803/229604492-5ba63856-9716-4f46-94cc-e14a8714afba.png">
<img width="1654" alt="Screenshot 2023-04-03 at 3 16 36 PM" src="https://user-images.githubusercontent.com/62672803/229605412-75081c72-0e6a-48a0-9ba2-c29f246558e0.png">
