### PR TITLE
127 fix time slot edit mode

### DIFF
--- a/client/src/components/Schedule/TimeSlot.tsx
+++ b/client/src/components/Schedule/TimeSlot.tsx
@@ -303,11 +303,11 @@ function TimeSlot(props: Props) {
             ) : (
               <div className="flex justify-center gap-3 text-2xl dark:text-white">
                 <div>Days:</div>
-                <div>{days?.monday && <>M</>}</div>
-                <div>{days?.tuesday && <>T</>}</div>
-                <div>{days?.wednesday && <>W</>}</div>
-                <div>{days?.thursday && <>TH</>}</div>
-                <div>{days?.friday && <>F</>}</div>
+                <div>{days?.monday && 'M'}</div>
+                <div>{days?.tuesday && 'T'}</div>
+                <div>{days?.wednesday && 'W'}</div>
+                <div>{days?.thursday && 'TH'}</div>
+                <div>{days?.friday && 'F'}</div>
               </div>
             )}
             <div className="flex justify-evenly">
@@ -326,10 +326,10 @@ function TimeSlot(props: Props) {
                     />
                   </>
                 ) : (
-                  <div className="text-2xl dark:text-white">
-                    <p>Location:</p>
-                    <span>
-                      {props.location === null ? <>null</> : props.location}
+                  <div className="text-2xl dark:text-white space-x-2">
+                    <span>Location:</span>
+                    <span className='capitalize'>
+                      {props.location ? props.location : 'N/A'}
                     </span>
                   </div>
                 )}
@@ -349,10 +349,10 @@ function TimeSlot(props: Props) {
                     />
                   </>
                 ) : (
-                  <div className="text-2xl dark:text-white">
-                    <p>Professor:</p>
-                    <span>
-                      {props.professor === null ? <>null</> : props.professor}
+                  <div className="text-2xl dark:text-white space-x-2">
+                    <span>Professor:</span>
+                    <span className='capitalize'>
+                      {props.professor ? props.professor : 'N/A'}
                     </span>
                   </div>
                 )}

--- a/client/src/components/Schedule/TimeSlot.tsx
+++ b/client/src/components/Schedule/TimeSlot.tsx
@@ -49,7 +49,7 @@ function TimeSlot(props: Props) {
   const thursdayRef = useRef(document.createElement('input'));
   const fridayRef = useRef(document.createElement('input'));
 
-  // Refs
+  // Input Refs
   const titleRef = useRef(document.createElement('input'));
   const startTimeRef = useRef(document.createElement('input'));
   const endTimeRef = useRef(document.createElement('input'));

--- a/client/src/components/Schedule/TimeSlot.tsx
+++ b/client/src/components/Schedule/TimeSlot.tsx
@@ -42,9 +42,6 @@ function TimeSlot(props: Props) {
   const [isTimeSlotClicked, setIsTimeSlotClicked] = useState<boolean>(false);
   const [timeSlotColor, setTimeSlotColor] = useState<string>('border-none');
   const [editMode, setEditMode] = useState<boolean>(false);
-  const [title, setTitle] = useState<string>(props.title);
-  const [startTime, setStartTime] = useState<string>(props.startTime);
-  const [endTime, setEndTime] = useState<string>(props.endTime);
   const [days, setDays] = useState<DaysCheckedType>(props.days);
   const mondayRef = useRef(document.createElement('input'));
   const tuesdayRef = useRef(document.createElement('input'));
@@ -52,12 +49,21 @@ function TimeSlot(props: Props) {
   const thursdayRef = useRef(document.createElement('input'));
   const fridayRef = useRef(document.createElement('input'));
 
-  const [location, setLocation] = useState<string | null>(
-    props.location ?? null
-  );
-  const [professor, setProfessor] = useState<string | null>(
-    props.professor ?? null
-  );
+  // Refs
+  const titleRef = useRef(document.createElement('input'));
+  const startTimeRef = useRef(document.createElement('input'));
+  const endTimeRef = useRef(document.createElement('input'));
+  const locationRef = useRef(document.createElement('input'));
+  const professorRef = useRef(document.createElement('input'));
+
+  useEffect(() => {
+    if (titleRef.current) titleRef.current.value = props.title;
+    if (startTimeRef.current) startTimeRef.current.value = props.startTime;
+    if (endTimeRef.current) endTimeRef.current.value = props.endTime;
+    if (locationRef.current) locationRef.current.value = props.location || '';
+    if (professorRef.current) professorRef.current.value = props.professor || '';
+  }, [editMode]);
+
   useEffect(() => {
     setTimeSlotColor(props.color);
   }, []);
@@ -65,14 +71,15 @@ function TimeSlot(props: Props) {
   const saveHandler = async () => {
     const updatedTimeSlot: TimeSlotType = {
       _id: props.id!,
-      title: title,
-      startTime: startTime,
-      endTime: endTime,
+      title: titleRef.current.value,
+      startTime: startTimeRef.current.value,
+      endTime: endTimeRef.current.value,
       color: timeSlotColor,
-      professor: professor,
-      location: location,
+      professor: professorRef.current.value,
+      location: locationRef.current.value,
       days: props.days,
     };
+
     if (
       !(
         mondayRef.current.checked ||
@@ -163,8 +170,7 @@ function TimeSlot(props: Props) {
                   <input
                     id="title"
                     type="text"
-                    placeholder={props.title}
-                    onBlur={(event) => setTitle(event.target.value)}
+                    ref={titleRef}
                     className="w-full rounded-md focus:ring focus:ring-blue-400 focus:ring-opacity-75 dark:border-gray-700 dark:text-gray-900"
                   />
                 </div>
@@ -183,13 +189,12 @@ function TimeSlot(props: Props) {
                   <input
                     id="startTime"
                     type="text"
-                    placeholder={props.startTime}
-                    onBlur={(event) => setStartTime(event.target.value)}
+                    ref={startTimeRef}
                     className="w-full rounded-md focus:ring focus:ring-blue-400 focus:ring-opacity-75 dark:border-gray-700 dark:text-gray-900"
                   />
                 </div>
               ) : (
-                <span className='mx-3'>{props.startTime}</span>
+                <span className="mx-3">{props.startTime}</span>
               )}
 
               {!editMode && '-'}
@@ -202,13 +207,12 @@ function TimeSlot(props: Props) {
                   <input
                     id="endTime"
                     type="text"
-                    placeholder={props.endTime}
-                    onBlur={(event) => setEndTime(event.target.value)}
+                    ref={endTimeRef}
                     className="w-full rounded-md focus:ring focus:ring-blue-400 focus:ring-opacity-75 dark:border-gray-700 dark:text-gray-900"
                   />
                 </div>
               ) : (
-                <span className='mx-3'>{props.endTime}</span>
+                <span className="mx-3">{props.endTime}</span>
               )}
             </div>
 
@@ -302,7 +306,7 @@ function TimeSlot(props: Props) {
               </ul>
             ) : (
               <div className="flex justify-center gap-3 text-2xl dark:text-white">
-                <span className='font-semibold'>Days:</span>
+                <span className="font-semibold">Days:</span>
                 <span>{days?.monday && 'M'}</span>
                 <span>{days?.tuesday && 'T'}</span>
                 <span>{days?.wednesday && 'W'}</span>
@@ -314,21 +318,24 @@ function TimeSlot(props: Props) {
               <div>
                 {editMode ? (
                   <>
-                    <label htmlFor="location" className="text-sm dark:text-white">
+                    <label
+                      htmlFor="location"
+                      className="text-sm dark:text-white"
+                    >
                       Location
                     </label>
                     <input
                       id="location"
                       type="text"
-                      onBlur={(event) => setLocation(event.target.value)}
-                      placeholder={props.location!}
+                      ref={locationRef}
+                      placeholder="Enter location"
                       className="w-full rounded-md focus:ring focus:ring-blue-400 focus:ring-opacity-75 dark:border-gray-700 dark:text-gray-900"
                     />
                   </>
                 ) : (
-                  <div className="text-2xl dark:text-white space-x-2">
-                    <span className='font-semibold'>Location:</span>
-                    <span className='capitalize'>
+                  <div className="space-x-2 text-2xl dark:text-white">
+                    <span className="font-semibold">Location:</span>
+                    <span className="capitalize">
                       {props.location ? props.location : 'N/A'}
                     </span>
                   </div>
@@ -337,21 +344,24 @@ function TimeSlot(props: Props) {
               <div>
                 {editMode ? (
                   <>
-                    <label htmlFor="professor" className="text-sm dark:text-white">
+                    <label
+                      htmlFor="professor"
+                      className="text-sm dark:text-white"
+                    >
                       Professor
                     </label>
                     <input
                       id="professor"
                       type="text"
-                      placeholder={props.professor!}
-                      onBlur={(event) => setProfessor(event.target.value)}
+                      placeholder="Enter professor's name"
+                      ref={professorRef}
                       className="w-full rounded-md focus:ring focus:ring-blue-400 focus:ring-opacity-75 dark:border-gray-700 dark:text-gray-900"
                     />
                   </>
                 ) : (
-                  <div className="text-2xl dark:text-white space-x-2">
-                    <span className='font-semibold'>Professor:</span>
-                    <span className='capitalize'>
+                  <div className="space-x-2 text-2xl dark:text-white">
+                    <span className="font-semibold">Professor:</span>
+                    <span className="capitalize">
                       {props.professor ? props.professor : 'N/A'}
                     </span>
                   </div>

--- a/client/src/components/Schedule/TimeSlot.tsx
+++ b/client/src/components/Schedule/TimeSlot.tsx
@@ -157,7 +157,7 @@ function TimeSlot(props: Props) {
             <div className="flex justify-center">
               {editMode ? (
                 <div className="w-1/2">
-                  <label htmlFor="title" className="text-3xl">
+                  <label htmlFor="title" className="text-3xl dark:text-white">
                     Title
                   </label>
                   <input
@@ -189,10 +189,10 @@ function TimeSlot(props: Props) {
                   />
                 </div>
               ) : (
-                <span>{props.startTime}</span>
+                <span className='mx-3'>{props.startTime}</span>
               )}
 
-              {!editMode && <>-</>}
+              {!editMode && '-'}
 
               {editMode ? (
                 <div className="w-1/6">
@@ -208,7 +208,7 @@ function TimeSlot(props: Props) {
                   />
                 </div>
               ) : (
-                <span>{props.endTime}</span>
+                <span className='mx-3'>{props.endTime}</span>
               )}
             </div>
 
@@ -302,19 +302,19 @@ function TimeSlot(props: Props) {
               </ul>
             ) : (
               <div className="flex justify-center gap-3 text-2xl dark:text-white">
-                <div>Days:</div>
-                <div>{days?.monday && 'M'}</div>
-                <div>{days?.tuesday && 'T'}</div>
-                <div>{days?.wednesday && 'W'}</div>
-                <div>{days?.thursday && 'TH'}</div>
-                <div>{days?.friday && 'F'}</div>
+                <span className='font-semibold'>Days:</span>
+                <span>{days?.monday && 'M'}</span>
+                <span>{days?.tuesday && 'T'}</span>
+                <span>{days?.wednesday && 'W'}</span>
+                <span>{days?.thursday && 'TH'}</span>
+                <span>{days?.friday && 'F'}</span>
               </div>
             )}
             <div className="flex justify-evenly">
               <div>
                 {editMode ? (
                   <>
-                    <label htmlFor="location" className="text-sm">
+                    <label htmlFor="location" className="text-sm dark:text-white">
                       Location
                     </label>
                     <input
@@ -327,7 +327,7 @@ function TimeSlot(props: Props) {
                   </>
                 ) : (
                   <div className="text-2xl dark:text-white space-x-2">
-                    <span>Location:</span>
+                    <span className='font-semibold'>Location:</span>
                     <span className='capitalize'>
                       {props.location ? props.location : 'N/A'}
                     </span>
@@ -337,7 +337,7 @@ function TimeSlot(props: Props) {
               <div>
                 {editMode ? (
                   <>
-                    <label htmlFor="professor" className="text-sm">
+                    <label htmlFor="professor" className="text-sm dark:text-white">
                       Professor
                     </label>
                     <input
@@ -350,7 +350,7 @@ function TimeSlot(props: Props) {
                   </>
                 ) : (
                   <div className="text-2xl dark:text-white space-x-2">
-                    <span>Professor:</span>
+                    <span className='font-semibold'>Professor:</span>
                     <span className='capitalize'>
                       {props.professor ? props.professor : 'N/A'}
                     </span>

--- a/client/src/pages/CompareSchedule.tsx
+++ b/client/src/pages/CompareSchedule.tsx
@@ -1,7 +1,7 @@
 import ScheduleBox from '../components/Schedule/ScheduleBox';
 import { useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
-import { useGetScheduleQuery } from '../redux/services/auth/authService';
+import { useGetScheduleQuery } from '../redux/services/schedule/scheduleService';
 import { Button } from 'flowbite-react';
 
 type days = {
@@ -35,7 +35,7 @@ type Schedule = {
 const CompareSchedule = () => {
   const { userId } = useParams();
 
-  // This states are used to conditionallly render the titles of the scheduls and the toggles.
+  // This states are used to conditionallly render the titles of the schedules and the toggles.
   const [showOtherSchedule, setShowOtherSchedule] = useState<boolean>(true);
   const [showUserSchedule, setShowUserSchedule] = useState<boolean>(false);
   const [showCompareSchedule, setShowCompareSchedule] =


### PR DESCRIPTION
This PR solves the following issues:

- Adds white color to the titles of the edit mode in the time slot component when dark mode is on.
- Adds initial value to the inputs in the time slot edit mode.
- Replaces NULL with N/A in case that data for the professor and location fields was not provided by the user.
- Fixes bug in which the comparison schedule would fall behind when a user made any changes to their schedule. and needed a page refresh to display the correct data.


![Screen Shot 2023-04-24 at 9 41 33 AM](https://user-images.githubusercontent.com/62437724/234014852-9ceb6c37-e55f-4c58-9917-004ede845f93.png)

Addresses #127 
