### PR TITLE
130 make time slots readonly on compare page

### DIFF
--- a/client/src/components/Schedule/TimeSlot.tsx
+++ b/client/src/components/Schedule/TimeSlot.tsx
@@ -12,6 +12,7 @@ import {
   useUpdateTimeSlotMutation,
 } from '../../redux/services/schedule/scheduleService';
 import { useGetScheduleQuery } from '../../redux/services/auth/authService';
+import { useAppSelector } from '../../redux/store';
 
 type Props = {
   id?: undefined | string;
@@ -35,6 +36,9 @@ function TimeSlot(props: Props) {
   if (!isFetching) {
     scheduleID = data[0]._id;
   }
+
+  // Check if the time slot is readonly
+  const readOnly: boolean = useAppSelector((state) => state.timeSlot.readOnly);
 
   const [deleteTimeSlotMutation] = useDeleteTimeSlotMutation();
   const [updateTimeSlotMutation] = useUpdateTimeSlotMutation();
@@ -61,7 +65,8 @@ function TimeSlot(props: Props) {
     if (startTimeRef.current) startTimeRef.current.value = props.startTime;
     if (endTimeRef.current) endTimeRef.current.value = props.endTime;
     if (locationRef.current) locationRef.current.value = props.location || '';
-    if (professorRef.current) professorRef.current.value = props.professor || '';
+    if (professorRef.current)
+      professorRef.current.value = props.professor || '';
   }, [editMode]);
 
   useEffect(() => {
@@ -406,21 +411,19 @@ function TimeSlot(props: Props) {
         </Modal.Body>
       </Modal>
       <div
-        className={`absolute flex flex-col items-center justify-start gap-1 rounded-lg p-3 text-xs bg-${props.color}-400 w-full hover:cursor-pointer hover:brightness-50 dark:text-black`}
+        className={`absolute flex flex-col items-center justify-start gap-1 rounded-lg p-3 text-xs bg-${props.color}-400 w-full ${!readOnly && 'hover:cursor-pointer hover:brightness-50'} dark:text-black`}
         style={{ top: `${props.top}px`, height: `${props.height}px` }}
-        onClick={() => setIsTimeSlotClicked(true)}
-        onMouseEnter={() => setIsHovering(true)}
+        onClick={() => setIsTimeSlotClicked(readOnly ? false : true)}
+        onMouseEnter={() => setIsHovering(readOnly ? false:true)}
         onMouseLeave={() => setIsHovering(false)}
       >
-        <>
-          {isHovering && <AiFillEdit size={'96'} />}
-          {parseInt(props.height) > 55 && (
-            <div className='flex flex-col items-center gap-1'>
-              <h2 className="font-bold text-center">{props.title}</h2>
-              <span>{`${props.startTime} - ${props.endTime}`}</span>
-            </div>
-          )}
-        </>
+        {isHovering && <AiFillEdit size={'96'} />}
+        {parseInt(props.height) > 55 && (
+          <div className="flex flex-col items-center gap-1">
+            <h2 className="text-center font-bold">{props.title}</h2>
+            <span>{`${props.startTime} - ${props.endTime}`}</span>
+          </div>
+        )}
       </div>
     </>
   );

--- a/client/src/components/Schedule/TimeSlot.tsx
+++ b/client/src/components/Schedule/TimeSlot.tsx
@@ -415,8 +415,8 @@ function TimeSlot(props: Props) {
         <>
           {isHovering && <AiFillEdit size={'96'} />}
           {parseInt(props.height) > 55 && (
-            <div>
-              <h2 className="text-center font-bold">{props.title}</h2>
+            <div className='flex flex-col items-center gap-1'>
+              <h2 className="font-bold text-center">{props.title}</h2>
               <span>{`${props.startTime} - ${props.endTime}`}</span>
             </div>
           )}

--- a/client/src/components/Schedule/TimeSlotInput.tsx
+++ b/client/src/components/Schedule/TimeSlotInput.tsx
@@ -5,9 +5,7 @@ import { DaysChecked, TimeSlot as TimeSlotType } from '../../types';
 import { convertTo24Hour, validTimeSlot } from '../../utils/scheduleUtils';
 import { Modal, Button } from 'flowbite-react';
 import { AiFillWarning } from 'react-icons/ai';
-type Props = {
-  setTimeSlots: any;
-};
+type Props = {};
 
 export const colors: string[] = [
   'slate',

--- a/client/src/pages/CompareSchedule.tsx
+++ b/client/src/pages/CompareSchedule.tsx
@@ -3,6 +3,8 @@ import { useParams } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import { useGetScheduleQuery } from '../redux/services/schedule/scheduleService';
 import { Button } from 'flowbite-react';
+import { useAppDispatch } from '../redux/store';
+import { toggleReadOnly } from '../redux/feats/timeSlot/timeSlotSlice';
 
 type days = {
   monday: boolean;
@@ -34,6 +36,9 @@ type Schedule = {
 
 const CompareSchedule = () => {
   const { userId } = useParams();
+
+  const dispatch = useAppDispatch();
+  dispatch(toggleReadOnly(true));
 
   // This states are used to conditionallly render the titles of the schedules and the toggles.
   const [showOtherSchedule, setShowOtherSchedule] = useState<boolean>(true);

--- a/client/src/pages/Schedule.tsx
+++ b/client/src/pages/Schedule.tsx
@@ -1,10 +1,16 @@
 import TimeSlotInput from '../components/Schedule/TimeSlotInput';
 import ScheduleBox from '../components/Schedule/ScheduleBox';
 import Toggle from '../components/Toggle';
+import { useAppDispatch } from '../redux/store';
+import { toggleReadOnly } from '../redux/feats/timeSlot/timeSlotSlice';
 
 type Props = {};
 
 function Schedule({}: Props) {
+
+  const dispatch = useAppDispatch();
+  dispatch(toggleReadOnly(false));
+
   return (
     <div className="flex h-[1110px] min-h-full flex-col gap-10 bg-slate-400 px-8 dark:bg-slate-900 2xl:px-12">
       <div className="flex justify-end">

--- a/client/src/redux/feats/timeSlot/timeSlotSlice.ts
+++ b/client/src/redux/feats/timeSlot/timeSlotSlice.ts
@@ -1,0 +1,18 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  readOnly: false,
+};
+
+const timeSlotSlice = createSlice({
+  name: 'timeSlot',
+  initialState,
+  reducers: {
+    toggleReadOnly: (state, action) => {
+      state.readOnly = action.payload;
+    },
+  },
+});
+
+export default timeSlotSlice.reducer;
+export const { toggleReadOnly } = timeSlotSlice.actions;

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from './feats/auth/authSlice';
+import timeSlotReducer from './feats/timeSlot/timeSlotSlice'
 import { authAPI } from './services/auth/authService';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { scheduleAPI } from './services/schedule/scheduleService';
@@ -7,6 +8,7 @@ import { scheduleAPI } from './services/schedule/scheduleService';
 const store = configureStore({
   reducer: { 
     auth: authReducer,
+    timeSlot: timeSlotReducer,
     [authAPI.reducerPath]: authAPI.reducer,
     [scheduleAPI.reducerPath]: scheduleAPI.reducer,
   },


### PR DESCRIPTION
This PR does the following:

- Adds a Redux slice to handle the readonly state of the time slots.
- Uses the readonly state from the Redux slice to conditionally allow the timeslots to be edited. 

Addresses #130 